### PR TITLE
Fixed `template` as a function and `banner` config options

### DIFF
--- a/src/utils/parseBarrel.ts
+++ b/src/utils/parseBarrel.ts
@@ -14,7 +14,7 @@ export function parseBarrel(value: unknown): Barrel {
     throw new Error("Invalid barrel config. Config must be an object.");
   }
 
-  const { out, matchDirectory, match, matchIgnore, template } = value as Record<
+  const { out, matchDirectory, match, matchIgnore, template, banner } = value as Record<
     string,
     unknown
   >;
@@ -38,12 +38,15 @@ export function parseBarrel(value: unknown): Barrel {
     ? parseStringArray(matchIgnore, "matchIgnore")
     : undefined;
 
-  const parsedTemplate = typeof template === "string" ? template : undefined;
+  const parsedTemplate = (typeof template === "string" || typeof template === "function") ? template : undefined;
+  
+  const parsedBanner = typeof banner === "string" ? banner : undefined;
 
   return {
     out,
     matchDirectory: parsedMatchDirectory,
     template: parsedTemplate,
+    banner: parsedBanner,
     matchIgnore: parsedMatchIgnore,
     match: parsedMatch,
   };


### PR DESCRIPTION
They were missed in the parseBarrel() function.

Nice library, like the flexibility!